### PR TITLE
Switch images to master branch.

### DIFF
--- a/LOGIN.md
+++ b/LOGIN.md
@@ -1,19 +1,19 @@
-![Login One](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/auth-1.png)
+![Login One](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/auth-1.png)
 
 Click on `Authenticate`.
 
-![Login Two](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/auth-2.png)
+![Login Two](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/auth-2.png)
 
 You should see the above image. If you do not, make sure you have [authn.io](https://authn.io/) open in the browser and have visited it. Also ensure you have a valid wallet setup.
 
-![Login Three](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/auth-3.png)
+![Login Three](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/auth-3.png)
 
 Click on your wallet.
 
-![Login Four](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/auth-4.png)
+![Login Four](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/auth-4.png)
 
 Choose a Profile or Credential to use then click on `Authenticate`.
 
-![Login Five](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/auth-5.png)
+![Login Five](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/auth-5.png)
 
 You should end up on this screen.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Issuer Authentication](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/auth-1.png)
+![Issuer Authentication](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/auth-1.png)
 
 # demo-issuer-integration
 
@@ -59,9 +59,9 @@ The front end server will run on [https://localhost:19443](https://localhost:194
 
 ### Steps
 
-[Login steps.](https://github.com/digitalbazaar/demo-issuer-integration/blob/add-public-files/LOGIN.md)
+[Login steps.](https://github.com/digitalbazaar/demo-issuer-integration/blob/master/LOGIN.md)
 
-[Store Credential steps.](https://github.com/digitalbazaar/demo-issuer-integration/blob/add-public-files/STORE.md)
+[Store Credential steps.](https://github.com/digitalbazaar/demo-issuer-integration/blob/master/STORE.md)
 
 ---
 

--- a/STORE.md
+++ b/STORE.md
@@ -1,23 +1,23 @@
-![Store One](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/store-credential-1.png)
+![Store One](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/store-credential-1.png)
 
 Click on `STORE CREDENTIAL`.
 
-![Store Two](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/store-credential-2.png)
+![Store Two](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/store-credential-2.png)
 
 Click on `Next`.
 
-![Store Three](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/store-credential-3.png)
+![Store Three](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/store-credential-3.png)
 
 Click on your wallet.
 
-![Store Four](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/store-credential-4.png)
+![Store Four](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/store-credential-4.png)
 
 Choose a Credential then click on `Store`.
 
-![Store Five](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/store-credential-5.png)
+![Store Five](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/store-credential-5.png)
 
 You should end up on this screen.
 
-![Store Six](https://github.com/digitalbazaar/demo-issuer-integration/raw/add-public-files/images/store-credential-6.png)
+![Store Six](https://github.com/digitalbazaar/demo-issuer-integration/raw/master/images/store-credential-6.png)
 
 The credential should be in your wallet.


### PR DESCRIPTION
Fixes links to images in READMEs.

I can add a .dockerignore if you want, but I figured you might have one already:

https://github.com/digitalbazaar/chapi-demo-base/blob/fix-images-in-readme/LOGIN.md

https://github.com/digitalbazaar/chapi-demo-base/tree/fix-images-in-readme

https://github.com/digitalbazaar/chapi-demo-base/blob/fix-images-in-readme/STORE.md